### PR TITLE
Fix resolve modal handler collision

### DIFF
--- a/ERROR_LOG.md
+++ b/ERROR_LOG.md
@@ -4,3 +4,4 @@
 
 - **Incorrect PWA entry points**: `manifest.json` and `sw.js` referenced `Index.html` (capital `I`), which fails on case-sensitive hosts such as GitHub Pages and breaks installation/offline fallbacks. Updated both files to use the correct lowercase `index.html` paths.
 - **Hard-coded Alpha Vantage API key**: The production API key was committed directly in `index.html`, exposing the secret and breaking the user's own quota. Added a secure settings field that stores the key in local storage, added runtime guards, and updated documentation so live data only runs when a user supplies their own key.
+- **Shadowed modal close handler**: `index.html` declared both a DOM reference and a function named `closeResolveModal`, triggering a fatal `Identifier 'closeResolveModal' has already been declared` error in production. Renamed the DOM reference and function to unique identifiers and rewired event listeners so the script can execute on GitHub Pages.

--- a/index.html
+++ b/index.html
@@ -740,7 +740,7 @@
         const resolveModal = document.getElementById('resolve-modal');
         const resolveForm = document.getElementById('resolve-form');
         const cancelResolve = document.getElementById('cancel-resolve');
-        const closeResolveModal = document.getElementById('close-resolve-modal');
+        const closeResolveModalButton = document.getElementById('close-resolve-modal');
         const marketStatusText = document.getElementById('market-status-text');
         const marketStatusIcon = document.getElementById('market-status-icon');
         const predictionFormContainer = document.getElementById('prediction-form-container');
@@ -1523,7 +1523,7 @@
             resolveModal.classList.remove('hidden');
         }
 
-        function closeResolveModal() {
+        function hideResolveModal() {
             resolveModal.classList.add('hidden');
             currentResolveId = null;
         }
@@ -1660,7 +1660,7 @@
                 renderPendingPredictions();
                 renderHistory();
                 
-                closeResolveModal();
+                hideResolveModal();
                 
                 const actual = closePrice > openPrice ? 'up' : 'down';
                 const isCorrect = predictions[predictionIndex].prediction === actual;
@@ -1672,8 +1672,8 @@
             }
         });
 
-        cancelResolve.addEventListener('click', closeResolveModal);
-        closeResolveModal.addEventListener('click', closeResolveModal);
+        cancelResolve.addEventListener('click', hideResolveModal);
+        closeResolveModalButton.addEventListener('click', hideResolveModal);
 
         refreshLeaderboard.addEventListener('click', () => {
             renderLeaderboard();


### PR DESCRIPTION
## Summary
- rename the resolve modal close button reference to avoid shadowing the close handler function
- replace the close handler with a uniquely named helper and update all callers to prevent runtime errors
- document the resolved GitHub Pages startup error in the error log for future reference

## Testing
- python -m http.server 4173 (smoke test via Playwright)


------
https://chatgpt.com/codex/tasks/task_e_68ccb4b5d4008333a5be1854810e2660