### PR TITLE
Fix touch handling for launch prediction button

### DIFF
--- a/index.html
+++ b/index.html
@@ -1895,15 +1895,15 @@
 
         // Add touch optimizations
         function addTouchOptimizations() {
-            // Prevent double-tap zoom on buttons
-            document.querySelectorAll('button, .ios-button').forEach(button => {
-                button.addEventListener('touchstart', (e) => {
-                    e.preventDefault();
-                }, { passive: false });
+            // Rely on touch-action manipulation to avoid the 300ms delay without suppressing native click events
+            document.querySelectorAll('button').forEach((button) => {
+                if (!button.style.touchAction) {
+                    button.style.touchAction = 'manipulation';
+                }
             });
-            
+
             // Add haptic feedback for important actions
-            document.querySelectorAll('.resolve-btn, #submit-prediction, .ios-button').forEach(button => {
+            document.querySelectorAll('.resolve-btn, #submit-prediction, .ios-button').forEach((button) => {
                 button.addEventListener('click', () => {
                     if (navigator.vibrate) {
                         navigator.vibrate(30);


### PR DESCRIPTION
## Summary
- stop blocking native touch events on buttons while keeping fast tap interactions
- ensure buttons default to touch-action: manipulation and retain haptic feedback support

## Testing
- not run (project has no automated tests)


------
https://chatgpt.com/codex/tasks/task_e_68ccd84a92f48333abf837239adb9b9a