### PR TITLE
Configure Vercel runtime for Node 18 functions

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,7 @@
+{
+  "functions": {
+    "api/*.js": {
+      "runtime": "nodejs18.x"
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- add a Vercel deployment configuration to ensure Node.js 18 runtime for API functions

## Testing
- not run (configuration-only change)

------
https://chatgpt.com/codex/tasks/task_e_68cce6b07cf083338ad356f31afd01c3