### PR TITLE
fix: stabilize stock symbol search dropdown

### DIFF
--- a/dist/alphaVantage.js
+++ b/dist/alphaVantage.js
@@ -1,0 +1,183 @@
+const DEFAULT_CACHE_TTL_MS = 5 * 60 * 1000;
+const DEFAULT_CACHE_MAX_ENTRIES = 50;
+const isRecord = (value) => typeof value === 'object' && value !== null;
+const toCleanString = (value) => {
+    if (typeof value === 'string') {
+        const trimmed = value.trim();
+        return trimmed.length > 0 ? trimmed : undefined;
+    }
+    return undefined;
+};
+const toNumber = (value) => {
+    if (typeof value === 'number' && Number.isFinite(value)) {
+        return value;
+    }
+    if (typeof value === 'string') {
+        const parsed = Number.parseFloat(value);
+        return Number.isFinite(parsed) ? parsed : undefined;
+    }
+    return undefined;
+};
+const cloneMatches = (matches) => {
+    return matches.map((match) => ({ ...match }));
+};
+export const normalizeSymbolSearchKeyword = (keyword) => keyword.trim().toLowerCase();
+export const createSymbolSearchCache = (options = {}) => {
+    const ttlMs = typeof options.ttlMs === 'number' && options.ttlMs > 0 ? options.ttlMs : DEFAULT_CACHE_TTL_MS;
+    const maxEntries = typeof options.maxEntries === 'number' && options.maxEntries > 0
+        ? Math.floor(options.maxEntries)
+        : DEFAULT_CACHE_MAX_ENTRIES;
+    let accessSequence = 0;
+    const cache = new Map();
+    const set = (keyword, matches) => {
+        if (maxEntries === 0) {
+            return;
+        }
+        const normalizedKey = normalizeSymbolSearchKeyword(keyword);
+        if (!normalizedKey) {
+            return;
+        }
+        const now = Date.now();
+        accessSequence += 1;
+        cache.set(normalizedKey, {
+            matches: cloneMatches(matches),
+            expiresAt: now + ttlMs,
+            lastAccessed: accessSequence,
+        });
+        if (cache.size > maxEntries) {
+            let oldestKey = null;
+            let oldestAccess = Number.POSITIVE_INFINITY;
+            cache.forEach((entry, entryKey) => {
+                if (entry.lastAccessed < oldestAccess) {
+                    oldestAccess = entry.lastAccessed;
+                    oldestKey = entryKey;
+                }
+            });
+            if (oldestKey) {
+                cache.delete(oldestKey);
+            }
+        }
+    };
+    const get = (keyword) => {
+        const normalizedKey = normalizeSymbolSearchKeyword(keyword);
+        if (!normalizedKey) {
+            return null;
+        }
+        const entry = cache.get(normalizedKey);
+        if (!entry) {
+            return null;
+        }
+        const now = Date.now();
+        if (entry.expiresAt <= now) {
+            cache.delete(normalizedKey);
+            return null;
+        }
+        accessSequence += 1;
+        entry.lastAccessed = accessSequence;
+        return cloneMatches(entry.matches);
+    };
+    const clear = () => {
+        cache.clear();
+    };
+    const pruneExpired = (now = Date.now()) => {
+        Array.from(cache.entries()).forEach(([entryKey, entry]) => {
+            if (entry.expiresAt <= now) {
+                cache.delete(entryKey);
+            }
+        });
+    };
+    const size = () => cache.size;
+    return {
+        get,
+        set,
+        size,
+        clear,
+        pruneExpired,
+    };
+};
+const parseSymbolSearchMatch = (value) => {
+    if (!isRecord(value)) {
+        return null;
+    }
+    const symbol = toCleanString(value['1. symbol']);
+    const name = toCleanString(value['2. name']);
+    if (!symbol || !name) {
+        return null;
+    }
+    const match = {
+        symbol,
+        name,
+    };
+    const type = toCleanString(value['3. type']);
+    const region = toCleanString(value['4. region']);
+    const currency = toCleanString(value['8. currency']);
+    const score = toNumber(value['9. matchScore']);
+    if (type) {
+        match.type = type;
+    }
+    if (region) {
+        match.region = region;
+    }
+    if (currency) {
+        match.currency = currency;
+    }
+    if (typeof score === 'number') {
+        match.matchScore = score;
+    }
+    return match;
+};
+export const parseSymbolSearchResponse = (value) => {
+    if (!isRecord(value)) {
+        return {
+            matches: [],
+            message: 'Unexpected response from Alpha Vantage.',
+            isRateLimited: false,
+            isCacheable: false,
+        };
+    }
+    const note = toCleanString(value.Note);
+    if (note) {
+        return {
+            matches: [],
+            message: note,
+            isRateLimited: true,
+            isCacheable: false,
+        };
+    }
+    const information = toCleanString(value.Information);
+    if (information) {
+        return {
+            matches: [],
+            message: information,
+            isRateLimited: true,
+            isCacheable: false,
+        };
+    }
+    const errorMessage = toCleanString(value['Error Message']);
+    if (errorMessage) {
+        return {
+            matches: [],
+            message: errorMessage,
+            isRateLimited: false,
+            isCacheable: false,
+        };
+    }
+    const rawBestMatches = value.bestMatches;
+    if (!Array.isArray(rawBestMatches)) {
+        return {
+            matches: [],
+            message: 'Unexpected response from Alpha Vantage.',
+            isRateLimited: false,
+            isCacheable: false,
+        };
+    }
+    const matches = rawBestMatches
+        .map(parseSymbolSearchMatch)
+        .filter((match) => Boolean(match));
+    return {
+        matches,
+        message: undefined,
+        isRateLimited: false,
+        isCacheable: true,
+    };
+};

--- a/index.html
+++ b/index.html
@@ -254,6 +254,42 @@
             scrollbar-gutter: stable both;
         }
 
+        .symbol-results-message {
+            display: flex;
+            align-items: center;
+            gap: 0.5rem;
+            padding: 0.5rem 0.75rem;
+            font-size: 0.75rem;
+            color: #d1d5db;
+        }
+
+        .symbol-results-message--warning {
+            color: #fbbf24;
+        }
+
+        .symbol-results-message--error {
+            color: #f87171;
+        }
+
+        .symbol-results-message--loading {
+            color: #93c5fd;
+        }
+
+        .symbol-results-spinner {
+            width: 0.75rem;
+            height: 0.75rem;
+            border-radius: 9999px;
+            border: 2px solid currentColor;
+            border-right-color: transparent;
+            animation: symbol-results-spin 0.8s linear infinite;
+        }
+
+        @keyframes symbol-results-spin {
+            to {
+                transform: rotate(360deg);
+            }
+        }
+
         /* Smooth scrolling for iOS */
         .smooth-scroll {
             -webkit-overflow-scrolling: touch;
@@ -910,6 +946,10 @@
             mergeLeagueUsers,
             normalizeUsers
         } from './dist/prediction.js';
+        import {
+            createSymbolSearchCache,
+            parseSymbolSearchResponse
+        } from './dist/alphaVantage.js';
         import { z } from 'https://cdn.jsdelivr.net/npm/zod@3.23.8/+esm';
 
         // Data storage
@@ -929,6 +969,17 @@
         const SYMBOL_RESULTS_MIN_HEIGHT = 120;
         const SYMBOL_RESULTS_MAX_HEIGHT = 288;
         const SYMBOL_RESULTS_VIEWPORT_RATIO = 0.6;
+        const SYMBOL_SEARCH_MIN_QUERY_LENGTH = 2;
+        const SYMBOL_SEARCH_DEBOUNCE_MS = 350;
+
+        const symbolSearchCache = createSymbolSearchCache({
+            ttlMs: 5 * 60 * 1000,
+            maxEntries: 50
+        });
+
+        let symbolSearchDebounceId = null;
+        let symbolSearchAbortController = null;
+        let symbolSearchRequestToken = 0;
 
         // DOM Elements
         const dashboardTab = document.getElementById('dashboard-tab');
@@ -1151,21 +1202,45 @@
         }
 
         // Alpha Vantage API functions
-        async function searchStockSymbols(keyword) {
+        async function fetchSymbolMatches(keyword, signal) {
             if (!ensureAlphaVantageApiKey(false)) {
-                return [];
+                return {
+                    matches: [],
+                    message: 'Alpha Vantage API key required.',
+                    isRateLimited: false,
+                    isCacheable: false
+                };
             }
+
             try {
-                const response = await fetch(`https://www.alphavantage.co/query?function=SYMBOL_SEARCH&keywords=${keyword}&apikey=${alphaVantageApiKey}`);
-                const data = await response.json();
-                
-                if (data.bestMatches && data.bestMatches.length > 0) {
-                    return data.bestMatches.slice(0, 5); // Return top 5 matches
+                const response = await fetch(
+                    `https://www.alphavantage.co/query?function=SYMBOL_SEARCH&keywords=${encodeURIComponent(keyword)}&apikey=${alphaVantageApiKey}`,
+                    {
+                        signal,
+                        headers: {
+                            Accept: 'application/json'
+                        }
+                    }
+                );
+
+                if (!response.ok) {
+                    throw new Error(`Alpha Vantage responded with status ${response.status}`);
                 }
-                return [];
+
+                const data = await response.json();
+                return parseSymbolSearchResponse(data);
             } catch (error) {
+                if (error instanceof DOMException && error.name === 'AbortError') {
+                    return {
+                        matches: [],
+                        message: undefined,
+                        isRateLimited: false,
+                        isCacheable: false
+                    };
+                }
+
                 console.error('Error searching stock symbols:', error);
-                return [];
+                throw error;
             }
         }
 
@@ -1406,6 +1481,37 @@
         }
 
         // Symbol search functions
+        const HTML_ESCAPE_LOOKUP = {
+            '&': '&amp;',
+            '<': '&lt;',
+            '>': '&gt;',
+            '"': '&quot;',
+            "'": '&#39;',
+            '`': '&#96;'
+        };
+
+        const escapeHtml = (value) => {
+            if (value === null || value === undefined) {
+                return '';
+            }
+
+            return String(value).replace(/[&<>"'`]/g, (char) => HTML_ESCAPE_LOOKUP[char] || char);
+        };
+
+        function clearSymbolSearchDebounce() {
+            if (symbolSearchDebounceId !== null) {
+                clearTimeout(symbolSearchDebounceId);
+                symbolSearchDebounceId = null;
+            }
+        }
+
+        function abortActiveSymbolSearch() {
+            if (symbolSearchAbortController) {
+                symbolSearchAbortController.abort();
+                symbolSearchAbortController = null;
+            }
+        }
+
         function updateSymbolSearchDropdownPlacement() {
             if (!symbolSearchResults || !symbolResultsScroll || !symbolInputWrapper) {
                 return;
@@ -1465,31 +1571,27 @@
             updateSymbolSearchDropdownPlacement();
         }
 
-        function showSymbolSearchResults(results) {
+        function showSymbolSearchMessage(message, tone = 'info') {
             if (!symbolSearchResults || !symbolResultsList) {
                 return;
             }
 
-            if (results.length === 0) {
-                symbolResultsList.innerHTML = '<li class="px-2.5 py-1.5 text-gray-400 text-xs">No matches found</li>';
-            } else {
-                symbolResultsList.innerHTML = results.map(match => `
-                    <li class="symbol-result px-2.5 py-1.5 cursor-pointer hover:bg-cyan-900/30 transition-colors"
-                        data-symbol="${match['1. symbol']}" role="option" tabindex="-1">
-                        <div class="font-exo font-bold text-xs">${match['1. symbol']}</div>
-                        <div class="text-[10px] text-gray-400 truncate">${match['2. name']}</div>
-                    </li>
-                `).join('');
+            const toneClassMap = {
+                info: 'symbol-results-message text-gray-300',
+                warning: 'symbol-results-message symbol-results-message--warning',
+                error: 'symbol-results-message symbol-results-message--error',
+                loading: 'symbol-results-message symbol-results-message--loading'
+            };
 
-                symbolResultsList.querySelectorAll('.symbol-result').forEach((item) => {
-                    item.addEventListener('click', () => {
-                        const symbol = item.dataset.symbol;
-                        symbolInput.value = symbol;
-                        hideSymbolSearchResults();
-                        renderStockDetails(symbol);
-                    });
-                });
-            }
+            const toneClass = toneClassMap[tone] || toneClassMap.info;
+            const spinner = tone === 'loading' ? '<span class="symbol-results-spinner" aria-hidden="true"></span>' : '';
+
+            symbolResultsList.innerHTML = `
+                <li class="${toneClass}">
+                    ${spinner}
+                    <span>${escapeHtml(message)}</span>
+                </li>
+            `;
 
             updateSymbolSearchDropdownPlacement();
             symbolSearchResults.classList.remove('hidden');
@@ -1498,8 +1600,71 @@
             if (symbolResultsScroll) {
                 symbolResultsScroll.scrollTop = 0;
             }
+        }
+
+        function showSymbolSearchLoading() {
+            showSymbolSearchMessage('Searching…', 'loading');
+        }
+
+        function showSymbolSearchResults(matches) {
+            if (!symbolSearchResults || !symbolResultsList) {
+                return;
+            }
+
+            if (!matches || matches.length === 0) {
+                showSymbolSearchMessage('No matches found', 'info');
+                return;
+            }
+
+            symbolResultsList.innerHTML = matches.map((match) => {
+                const metaParts = [];
+                if (match.region) {
+                    metaParts.push(match.region);
+                }
+                if (match.currency) {
+                    metaParts.push(match.currency);
+                }
+
+                const metaLine = metaParts.length
+                    ? `<div class="text-[10px] text-gray-500 truncate">${escapeHtml(metaParts.join(' • '))}</div>`
+                    : '';
+
+                let scoreLine = '';
+                if (typeof match.matchScore === 'number' && Number.isFinite(match.matchScore)) {
+                    const scorePercent = Math.round(match.matchScore * 100);
+                    scoreLine = `<div class="text-[10px] text-gray-500">Match score: ${escapeHtml(`${scorePercent}%`)}</div>`;
+                }
+
+                return `
+                    <li class="symbol-result px-2.5 py-1.5 cursor-pointer hover:bg-cyan-900/30 transition-colors"
+                        data-symbol="${escapeHtml(match.symbol)}" role="option" tabindex="-1">
+                        <div class="font-exo font-bold text-xs">${escapeHtml(match.symbol)}</div>
+                        <div class="text-[10px] text-gray-400 truncate">${escapeHtml(match.name)}</div>
+                        ${metaLine}
+                        ${scoreLine}
+                    </li>
+                `;
+            }).join('');
+
+            symbolResultsList.querySelectorAll('.symbol-result').forEach((item) => {
+                item.addEventListener('click', () => {
+                    const symbol = item.dataset.symbol;
+                    if (symbol) {
+                        symbolInput.value = symbol;
+                        hideSymbolSearchResults();
+                        renderStockDetails(symbol);
+                    }
+                });
+            });
 
             applyTouchOptimizationsToTree(symbolResultsList);
+            updateSymbolSearchDropdownPlacement();
+            symbolSearchResults.classList.remove('hidden');
+            symbolSearchResults.setAttribute('aria-hidden', 'false');
+
+            if (symbolResultsScroll) {
+                symbolResultsScroll.scrollTop = 0;
+            }
         }
 
         function hideSymbolSearchResults() {
@@ -1515,6 +1680,93 @@
                 symbolResultsScroll.style.maxHeight = '';
                 symbolResultsScroll.scrollTop = 0;
             }
+        }
+
+        async function performSymbolSearch(keyword, requestToken) {
+            abortActiveSymbolSearch();
+
+            const controller = new AbortController();
+            symbolSearchAbortController = controller;
+
+            try {
+                const parsed = await fetchSymbolMatches(keyword, controller.signal);
+
+                if (requestToken !== symbolSearchRequestToken) {
+                    return;
+                }
+
+                if (parsed.isRateLimited) {
+                    showSymbolSearchMessage(
+                        parsed.message || 'API rate limit reached. Please wait a moment before trying again.',
+                        'warning'
+                    );
+                    return;
+                }
+
+                if (parsed.message) {
+                    showSymbolSearchMessage(parsed.message, 'info');
+                    return;
+                }
+
+                const matches = parsed.matches.slice(0, 5);
+
+                if (parsed.isCacheable) {
+                    symbolSearchCache.set(keyword, matches);
+                }
+
+                showSymbolSearchResults(matches);
+            } catch (error) {
+                if (error instanceof DOMException && error.name === 'AbortError') {
+                    return;
+                }
+
+                console.error('Error searching stock symbols:', error);
+
+                if (requestToken === symbolSearchRequestToken) {
+                    showSymbolSearchMessage(
+                        'Unable to fetch symbol matches. Check your connection and try again.',
+                        'error'
+                    );
+                }
+            } finally {
+                symbolSearchAbortController = null;
+            }
+        }
+
+        function scheduleSymbolSearch(rawKeyword) {
+            const keyword = rawKeyword.trim();
+
+            if (keyword.length < SYMBOL_SEARCH_MIN_QUERY_LENGTH) {
+                symbolSearchRequestToken += 1;
+                clearSymbolSearchDebounce();
+                abortActiveSymbolSearch();
+                hideSymbolSearchResults();
+                return;
+            }
+
+            if (!ensureAlphaVantageApiKey()) {
+                hideSymbolSearchResults();
+                return;
+            }
+
+            const cachedMatches = symbolSearchCache.get(keyword);
+
+            symbolSearchRequestToken += 1;
+            const requestToken = symbolSearchRequestToken;
+
+            if (cachedMatches !== null) {
+                showSymbolSearchResults(cachedMatches);
+                return;
+            }
+
+            abortActiveSymbolSearch();
+            clearSymbolSearchDebounce();
+            showSymbolSearchLoading();
+
+            symbolSearchDebounceId = window.setTimeout(() => {
+                symbolSearchDebounceId = null;
+                performSymbolSearch(keyword, requestToken);
+            }, SYMBOL_SEARCH_DEBOUNCE_MS);
         }
 
         // Render functions
@@ -1852,18 +2104,8 @@
             }
         });
 
-        symbolInput.addEventListener('input', async (e) => {
-            const keyword = e.target.value.trim();
-            if (keyword.length > 1) {
-                if (!ensureAlphaVantageApiKey()) {
-                    hideSymbolSearchResults();
-                    return;
-                }
-                const results = await searchStockSymbols(keyword);
-                showSymbolSearchResults(results);
-            } else {
-                hideSymbolSearchResults();
-            }
+        symbolInput.addEventListener('input', (e) => {
+            scheduleSymbolSearch(e.target.value);
         });
 
         symbolInput.addEventListener('focus', handleSymbolResultsViewportChange);
@@ -1871,6 +2113,10 @@
 
         // Close symbol search when clicking outside
         document.addEventListener('click', (e) => {
+            if (!symbolInput || !symbolSearchResults) {
+                return;
+            }
+
             if (!symbolInput.contains(e.target) && !symbolSearchResults.contains(e.target)) {
                 hideSymbolSearchResults();
             }

--- a/src/alphaVantage.test.ts
+++ b/src/alphaVantage.test.ts
@@ -1,0 +1,147 @@
+import { describe, expect, it, vi, beforeEach } from 'vitest';
+import {
+  createSymbolSearchCache,
+  normalizeSymbolSearchKeyword,
+  parseSymbolSearchResponse,
+  type SymbolSearchMatch,
+} from './alphaVantage';
+
+describe('normalizeSymbolSearchKeyword', () => {
+  it('trims whitespace and lowercases the keyword', () => {
+    expect(normalizeSymbolSearchKeyword('  AApL ')).toBe('aapl');
+  });
+
+  it('returns an empty string for whitespace-only input', () => {
+    expect(normalizeSymbolSearchKeyword('   ')).toBe('');
+  });
+});
+
+describe('createSymbolSearchCache', () => {
+  beforeEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('stores and retrieves cached results within ttl', () => {
+    const cache = createSymbolSearchCache({ ttlMs: 1000 });
+    const matches: SymbolSearchMatch[] = [{ symbol: 'AAPL', name: 'Apple Inc.' }];
+
+    cache.set('AAPL', matches);
+
+    const cached = cache.get('AAPL');
+    expect(cached).toEqual(matches);
+    expect(cache.size()).toBe(1);
+  });
+
+  it('expires entries after ttl', () => {
+    vi.useFakeTimers();
+    const cache = createSymbolSearchCache({ ttlMs: 1000 });
+    const matches: SymbolSearchMatch[] = [{ symbol: 'MSFT', name: 'Microsoft Corp.' }];
+
+    cache.set('MSFT', matches);
+
+    vi.advanceTimersByTime(1001);
+
+    expect(cache.get('MSFT')).toBeNull();
+    expect(cache.size()).toBe(0);
+  });
+
+  it('evicts the least recently used entry when max size exceeded', () => {
+    vi.useFakeTimers();
+    const cache = createSymbolSearchCache({ ttlMs: 5000, maxEntries: 2 });
+    const aapl: SymbolSearchMatch[] = [{ symbol: 'AAPL', name: 'Apple Inc.' }];
+    const msft: SymbolSearchMatch[] = [{ symbol: 'MSFT', name: 'Microsoft Corp.' }];
+    const goog: SymbolSearchMatch[] = [{ symbol: 'GOOG', name: 'Alphabet Inc.' }];
+
+    cache.set('AAPL', aapl);
+    cache.set('MSFT', msft);
+
+    // Access AAPL so MSFT becomes the least recently used entry
+    expect(cache.get('AAPL')).toEqual(aapl);
+
+    cache.set('GOOG', goog);
+
+    expect(cache.get('MSFT')).toBeNull();
+    expect(cache.get('AAPL')).toEqual(aapl);
+    expect(cache.get('GOOG')).toEqual(goog);
+  });
+});
+
+describe('parseSymbolSearchResponse', () => {
+  it('parses valid bestMatches array', () => {
+    const response = {
+      bestMatches: [
+        {
+          '1. symbol': 'AAPL',
+          '2. name': 'Apple Inc.',
+          '3. type': 'Equity',
+          '4. region': 'United States',
+          '8. currency': 'USD',
+          '9. matchScore': '0.8889',
+        },
+      ],
+    };
+
+    const result = parseSymbolSearchResponse(response);
+
+    expect(result.matches).toEqual([
+      {
+        symbol: 'AAPL',
+        name: 'Apple Inc.',
+        type: 'Equity',
+        region: 'United States',
+        currency: 'USD',
+        matchScore: 0.8889,
+      },
+    ]);
+    expect(result.isRateLimited).toBe(false);
+    expect(result.isCacheable).toBe(true);
+    expect(result.message).toBeUndefined();
+  });
+
+  it('handles rate limit note responses', () => {
+    const result = parseSymbolSearchResponse({ Note: 'Please try again later.' });
+
+    expect(result.matches).toEqual([]);
+    expect(result.isRateLimited).toBe(true);
+    expect(result.isCacheable).toBe(false);
+    expect(result.message).toBe('Please try again later.');
+  });
+
+  it('handles error message responses', () => {
+    const result = parseSymbolSearchResponse({ 'Error Message': 'Invalid API call.' });
+
+    expect(result.matches).toEqual([]);
+    expect(result.isRateLimited).toBe(false);
+    expect(result.isCacheable).toBe(false);
+    expect(result.message).toBe('Invalid API call.');
+  });
+
+  it('filters out invalid matches while remaining cacheable', () => {
+    const response = {
+      bestMatches: [
+        { '1. symbol': 'TSLA', '2. name': 'Tesla Inc.' },
+        { '1. symbol': '', '2. name': 'Invalid' },
+        { 'not a match': true },
+      ],
+    };
+
+    const result = parseSymbolSearchResponse(response);
+
+    expect(result.matches).toEqual([
+      {
+        symbol: 'TSLA',
+        name: 'Tesla Inc.',
+      },
+    ]);
+    expect(result.isCacheable).toBe(true);
+    expect(result.message).toBeUndefined();
+  });
+
+  it('returns an error message for unexpected structures', () => {
+    const result = parseSymbolSearchResponse({ foo: 'bar' });
+
+    expect(result.matches).toEqual([]);
+    expect(result.isCacheable).toBe(false);
+    expect(result.message).toBe('Unexpected response from Alpha Vantage.');
+  });
+});

--- a/src/alphaVantage.ts
+++ b/src/alphaVantage.ts
@@ -1,0 +1,272 @@
+export interface SymbolSearchMatch {
+  symbol: string;
+  name: string;
+  region?: string;
+  currency?: string;
+  matchScore?: number;
+  type?: string;
+}
+
+export interface ParsedSymbolSearchResponse {
+  matches: SymbolSearchMatch[];
+  message?: string;
+  isRateLimited: boolean;
+  isCacheable: boolean;
+}
+
+export interface SymbolSearchCacheOptions {
+  ttlMs?: number;
+  maxEntries?: number;
+}
+
+export interface SymbolSearchCache {
+  get(keyword: string): SymbolSearchMatch[] | null;
+  set(keyword: string, matches: SymbolSearchMatch[]): void;
+  size(): number;
+  clear(): void;
+  pruneExpired(now?: number): void;
+}
+
+const DEFAULT_CACHE_TTL_MS = 5 * 60 * 1000;
+const DEFAULT_CACHE_MAX_ENTRIES = 50;
+
+const isRecord = (value: unknown): value is Record<string, unknown> =>
+  typeof value === 'object' && value !== null;
+
+const toCleanString = (value: unknown): string | undefined => {
+  if (typeof value === 'string') {
+    const trimmed = value.trim();
+    return trimmed.length > 0 ? trimmed : undefined;
+  }
+
+  return undefined;
+};
+
+const toNumber = (value: unknown): number | undefined => {
+  if (typeof value === 'number' && Number.isFinite(value)) {
+    return value;
+  }
+
+  if (typeof value === 'string') {
+    const parsed = Number.parseFloat(value);
+    return Number.isFinite(parsed) ? parsed : undefined;
+  }
+
+  return undefined;
+};
+
+const cloneMatches = (matches: SymbolSearchMatch[]): SymbolSearchMatch[] => {
+  return matches.map((match) => ({ ...match }));
+};
+
+export const normalizeSymbolSearchKeyword = (keyword: string): string =>
+  keyword.trim().toLowerCase();
+
+export const createSymbolSearchCache = (
+  options: SymbolSearchCacheOptions = {},
+): SymbolSearchCache => {
+  const ttlMs =
+    typeof options.ttlMs === 'number' && options.ttlMs > 0 ? options.ttlMs : DEFAULT_CACHE_TTL_MS;
+  const maxEntries =
+    typeof options.maxEntries === 'number' && options.maxEntries > 0
+      ? Math.floor(options.maxEntries)
+      : DEFAULT_CACHE_MAX_ENTRIES;
+
+  let accessSequence = 0;
+  const cache = new Map<
+    string,
+    {
+      matches: SymbolSearchMatch[];
+      expiresAt: number;
+      lastAccessed: number;
+    }
+  >();
+
+  const set = (keyword: string, matches: SymbolSearchMatch[]): void => {
+    if (maxEntries === 0) {
+      return;
+    }
+
+    const normalizedKey = normalizeSymbolSearchKeyword(keyword);
+
+    if (!normalizedKey) {
+      return;
+    }
+
+    const now = Date.now();
+    accessSequence += 1;
+    cache.set(normalizedKey, {
+      matches: cloneMatches(matches),
+      expiresAt: now + ttlMs,
+      lastAccessed: accessSequence,
+    });
+
+    if (cache.size > maxEntries) {
+      let oldestKey: string | null = null;
+      let oldestAccess = Number.POSITIVE_INFINITY;
+
+      cache.forEach((entry, entryKey) => {
+        if (entry.lastAccessed < oldestAccess) {
+          oldestAccess = entry.lastAccessed;
+          oldestKey = entryKey;
+        }
+      });
+
+      if (oldestKey) {
+        cache.delete(oldestKey);
+      }
+    }
+  };
+
+  const get = (keyword: string): SymbolSearchMatch[] | null => {
+    const normalizedKey = normalizeSymbolSearchKeyword(keyword);
+
+    if (!normalizedKey) {
+      return null;
+    }
+
+    const entry = cache.get(normalizedKey);
+
+    if (!entry) {
+      return null;
+    }
+
+    const now = Date.now();
+
+    if (entry.expiresAt <= now) {
+      cache.delete(normalizedKey);
+      return null;
+    }
+
+    accessSequence += 1;
+    entry.lastAccessed = accessSequence;
+
+    return cloneMatches(entry.matches);
+  };
+
+  const clear = (): void => {
+    cache.clear();
+  };
+
+  const pruneExpired = (now: number = Date.now()): void => {
+    Array.from(cache.entries()).forEach(([entryKey, entry]) => {
+      if (entry.expiresAt <= now) {
+        cache.delete(entryKey);
+      }
+    });
+  };
+
+  const size = (): number => cache.size;
+
+  return {
+    get,
+    set,
+    size,
+    clear,
+    pruneExpired,
+  };
+};
+
+const parseSymbolSearchMatch = (value: unknown): SymbolSearchMatch | null => {
+  if (!isRecord(value)) {
+    return null;
+  }
+
+  const symbol = toCleanString(value['1. symbol']);
+  const name = toCleanString(value['2. name']);
+
+  if (!symbol || !name) {
+    return null;
+  }
+
+  const match: SymbolSearchMatch = {
+    symbol,
+    name,
+  };
+
+  const type = toCleanString(value['3. type']);
+  const region = toCleanString(value['4. region']);
+  const currency = toCleanString(value['8. currency']);
+  const score = toNumber(value['9. matchScore']);
+
+  if (type) {
+    match.type = type;
+  }
+
+  if (region) {
+    match.region = region;
+  }
+
+  if (currency) {
+    match.currency = currency;
+  }
+
+  if (typeof score === 'number') {
+    match.matchScore = score;
+  }
+
+  return match;
+};
+
+export const parseSymbolSearchResponse = (value: unknown): ParsedSymbolSearchResponse => {
+  if (!isRecord(value)) {
+    return {
+      matches: [],
+      message: 'Unexpected response from Alpha Vantage.',
+      isRateLimited: false,
+      isCacheable: false,
+    };
+  }
+
+  const note = toCleanString(value.Note);
+  if (note) {
+    return {
+      matches: [],
+      message: note,
+      isRateLimited: true,
+      isCacheable: false,
+    };
+  }
+
+  const information = toCleanString(value.Information);
+  if (information) {
+    return {
+      matches: [],
+      message: information,
+      isRateLimited: true,
+      isCacheable: false,
+    };
+  }
+
+  const errorMessage = toCleanString(value['Error Message']);
+  if (errorMessage) {
+    return {
+      matches: [],
+      message: errorMessage,
+      isRateLimited: false,
+      isCacheable: false,
+    };
+  }
+
+  const rawBestMatches = (value as { bestMatches?: unknown }).bestMatches;
+
+  if (!Array.isArray(rawBestMatches)) {
+    return {
+      matches: [],
+      message: 'Unexpected response from Alpha Vantage.',
+      isRateLimited: false,
+      isCacheable: false,
+    };
+  }
+
+  const matches = rawBestMatches
+    .map(parseSymbolSearchMatch)
+    .filter((match): match is SymbolSearchMatch => Boolean(match));
+
+  return {
+    matches,
+    message: undefined,
+    isRateLimited: false,
+    isCacheable: true,
+  };
+};


### PR DESCRIPTION
## Summary
- add an Alpha Vantage utility module with cached search helpers and robust response parsing
- enhance the in-browser stock selector with debounced requests, cached results, and user-facing loading/error states
- cover the new symbol search utilities with unit tests exercising caching and parser behavior

## Testing
- pnpm lint
- pnpm typecheck
- pnpm test
- pnpm build

------
https://chatgpt.com/codex/tasks/task_e_68ccf01f80488333970026b318309209